### PR TITLE
URL APIを使ったパースに置き換え

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,19 +2,17 @@ import {handleDefaultRequest} from "./handlers/handleDefaultRequest";
 import {handleMeRequest} from "./handlers/handleMeRequest";
 import {handleLoginRequest} from "./handlers/handleLoginRequest";
 
-const URL_REGEX = /^(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})(?<path>[/\w .-]*)*\/?$/;
-
 addEventListener('fetch', (event) => {
   const method = event.request.method;
-  const path = event.request.url.match(URL_REGEX)?.pop();
+  const url = new URL(event.request.url);
 
-  const route = `${method} ${path}`;
-  switch (route) {
-    case 'POST /login':
-      event.respondWith(handleLoginRequest(event.request)); break;
-    case 'GET /api/users/me':
-      event.respondWith(handleMeRequest(event.request)); break;
-    default:
-      event.respondWith(handleDefaultRequest(event.request));
+  if (method === 'POST' && url.pathname === '/login') {
+    event.respondWith(handleLoginRequest(event.request));
+  } else if (method === 'GET' && url.pathname === '/api/users/me') {
+    event.respondWith(handleMeRequest(event.request))
+  } else if (method === 'GET' && /\/api\/courses\/\w/.test(url.pathname)) {
+    // TODO: event.respondWith(handleCourseRequest(event.request))
+  } else {
+    event.respondWith(handleDefaultRequest(event.request));
   }
 })


### PR DESCRIPTION
正規表現でがんばらなくてもWorkers環境にある https://developer.mozilla.org/ja/docs/Web/API/URL/URL でパスを読み取ってくれる。

パラメータはsearchParamsに入っている
```js
>> (new URL(`http://127.0.0.1:8787/api/users/me?a=1`)).searchParams.get('a')
'1'
```

あと `/api/courses/:id` というコースIDのURLマッチが出てきて早くもswitch caseが破綻したのでベタなif-else式に書き換えた。